### PR TITLE
Replacing String with StringBuilder

### DIFF
--- a/src/main/java/com/github/rollingmetrics/histogram/util/Printer.java
+++ b/src/main/java/com/github/rollingmetrics/histogram/util/Printer.java
@@ -37,13 +37,13 @@ public class Printer {
     }
 
     public static String printArray(Object[] array, String elementName) {
-        String msg = "{";
+        StringBuilder msg = new StringBuilder("{");
         for (int i = 0; i < array.length; i++) {
             Object element = array[i];
-            msg += "\n" + elementName + "[" + i + "]=" + element;
+            msg.append("\n").append(elementName).append("[").append(i).append("]=").append(element);
         }
-        msg += "\n}";
-        return msg;
+        msg.append("\n}");
+        return msg.toString();
     }
-
+    
 }


### PR DESCRIPTION
Whenever a string is constructed using a loop that iterates more than just a few times, it is usually better to create a _StringBuffer_ or _StringBuilder_ object and append to that. 

If you think I am wrong, then please correct me.