### PR TITLE
integration with micrometer

### DIFF
--- a/doc-pages/integration/micrometer.md
+++ b/doc-pages/integration/micrometer.md
@@ -1,0 +1,23 @@
+# Integration with Micrometer (http://micrometer.io/)
+
+# Maven
+```xml
+<dependency>
+    <groupId>com.github.vladimir-bukhtoyarov</groupId>
+    <artifactId>rolling-metrics-micrometer</artifactId>
+    <version>...</version>
+</dependency>
+```
+
+# Spring-Boot
+```java
+@Bean
+public MeterRegistry meterRegistry(){
+    return new RollingMeterRegistry(
+        DistributionStatisticConfig.builder()
+            .expire(Duration.ofMinutes(window))
+            .bufferLength(chunkCount)
+            .build()
+    )
+}
+```

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <module>rolling-metrics-core</module>
         <module>rolling-metrics-dropwizard</module>
         <module>rolling-metrics-jmx</module>
+        <module>rolling-metrics-micrometer</module>
     </modules>
 
 </project>

--- a/rolling-metrics-micrometer/pom.xml
+++ b/rolling-metrics-micrometer/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~  Copyright 2017 Vladimir Bukhtoyarov
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~          http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>rolling-metrics-parent</artifactId>
+        <groupId>com.github.vladimir-bukhtoyarov</groupId>
+        <version>3.0.0-RC4</version>
+        <relativePath>../rolling-metrics-parent</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>rolling-metrics-micrometer</artifactId>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-bom</artifactId>
+                <version>1.3.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.vladimir-bukhtoyarov</groupId>
+            <artifactId>rolling-metrics-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.vladimir-bukhtoyarov</groupId>
+            <artifactId>rolling-metrics-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hdrhistogram</groupId>
+            <artifactId>HdrHistogram</artifactId>
+            <version>${hdr.histogram.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
+
+
+    </dependencies>
+
+
+</project>

--- a/rolling-metrics-micrometer/src/main/java/com/github/rollingmetrics/micrometer/RollingMeterRegistry.java
+++ b/rolling-metrics-micrometer/src/main/java/com/github/rollingmetrics/micrometer/RollingMeterRegistry.java
@@ -1,0 +1,129 @@
+package com.github.rollingmetrics.micrometer;
+
+import com.github.rollingmetrics.counter.SmoothlyDecayingRollingCounter;
+import com.github.rollingmetrics.micrometer.meters.*;
+import com.github.rollingmetrics.util.DaemonThreadFactory;
+import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.distribution.pause.PauseDetector;
+import io.micrometer.core.instrument.internal.DefaultGauge;
+import io.micrometer.core.instrument.internal.DefaultLongTaskTimer;
+import io.micrometer.core.instrument.internal.DefaultMeter;
+
+import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToLongFunction;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class RollingMeterRegistry extends MeterRegistry {
+    private static final Logger logger = Logger.getLogger(RollingMeterRegistry.class.getName());
+
+    private final DistributionStatisticConfig defaultConfig;
+    private final TickerClock tickerClock;
+
+    public RollingMeterRegistry(DistributionStatisticConfig defaultConfig) {
+        this(defaultConfig, Clock.SYSTEM);
+    }
+
+    protected RollingMeterRegistry(DistributionStatisticConfig defaultConfig, Clock clock) {
+        super(clock);
+        this.defaultConfig = defaultConfig;
+        this.tickerClock = new TickerClock(clock);
+
+        if (defaultConfig.getBufferLength() == null) {
+            throw new IllegalArgumentException("distributionStatisticConfig.getBufferLength() should not be null");
+        }
+        if (defaultConfig.getExpiry() == null) {
+            throw new IllegalArgumentException("distributionStatisticConfig.getExpiry() should not be null");
+        }
+
+        Executors.newScheduledThreadPool(1, new DaemonThreadFactory("rolling-meter-function-updater")).scheduleAtFixedRate(
+                () -> getMeters().forEach(meter -> {
+                    try {
+                        if (meter instanceof Updatable) {
+                            ((Updatable) meter).update();
+                        }
+                    } catch (Throwable t) {
+                        logger.log(Level.SEVERE, t, () -> "exception while updating meter " + meter.getId());
+                    }
+                }),
+                0,
+                defaultConfig.getExpiry().toMillis() / defaultConfig.getBufferLength(),
+                TimeUnit.MILLISECONDS
+        );
+    }
+
+    @Override
+    protected <T> Gauge newGauge(Meter.Id id, T obj, ToDoubleFunction<T> valueFunction) {
+        return new DefaultGauge<>(id, obj, valueFunction);
+    }
+
+    @Override
+    protected Counter newCounter(Meter.Id id) {
+        SmoothlyDecayingRollingCounter target = new SmoothlyDecayingRollingCounter(defaultConfig.getExpiry(), defaultConfig.getBufferLength(), tickerClock);
+        return new Counter() {
+            @Override
+            public void increment(double amount) {
+                target.add((long) amount);
+            }
+
+            @Override
+            public double count() {
+                return target.getSum();
+            }
+
+            @Override
+            public Id getId() {
+                return id;
+            }
+        };
+    }
+
+    @Override
+    protected LongTaskTimer newLongTaskTimer(Meter.Id id) {
+        return new DefaultLongTaskTimer(id, clock);
+    }
+
+    @Override
+    protected Timer newTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector) {
+        return new RollingTimer(
+                newDistributionSummary(id, distributionStatisticConfig, 1.0),
+                clock
+        );
+    }
+
+    @Override
+    protected RollingDistributionSummary newDistributionSummary(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, double scale) {
+        return new RollingDistributionSummary(id, distributionStatisticConfig, scale, clock);
+    }
+
+    @Override
+    protected Meter newMeter(Meter.Id id, Meter.Type type, Iterable<Measurement> measurements) {
+        return new DefaultMeter(id, type, measurements);
+    }
+
+    @Override
+    protected <T> FunctionTimer newFunctionTimer(Meter.Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit) {
+        return new RollingFunctionTimer<>(id, obj, countFunction, totalTimeFunction, totalTimeFunctionUnit, defaultConfig, tickerClock);
+    }
+
+    @Override
+    protected <T> FunctionCounter newFunctionCounter(Meter.Id id, T obj, ToDoubleFunction<T> countFunction) {
+        return new RollingFunctionCounter<>(id, obj, countFunction, defaultConfig, tickerClock);
+    }
+
+    @Override
+    protected TimeUnit getBaseTimeUnit() {
+        return TimeUnit.MILLISECONDS;
+    }
+
+    @Override
+    protected DistributionStatisticConfig defaultHistogramConfig() {
+        return defaultConfig;
+    }
+
+}

--- a/rolling-metrics-micrometer/src/main/java/com/github/rollingmetrics/micrometer/meters/RollingDistributionSummary.java
+++ b/rolling-metrics-micrometer/src/main/java/com/github/rollingmetrics/micrometer/meters/RollingDistributionSummary.java
@@ -1,0 +1,104 @@
+package com.github.rollingmetrics.micrometer.meters;
+
+import com.github.rollingmetrics.counter.SmoothlyDecayingRollingCounter;
+import com.github.rollingmetrics.histogram.OverflowResolver;
+import com.github.rollingmetrics.histogram.hdr.RollingHdrHistogram;
+import com.github.rollingmetrics.histogram.hdr.RollingSnapshot;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.distribution.CountAtBucket;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+import io.micrometer.core.instrument.distribution.ValueAtPercentile;
+
+public class RollingDistributionSummary implements DistributionSummary {
+    private final RollingHdrHistogram rollingHdrHistogram;
+    private final SmoothlyDecayingRollingCounter totalAmountCounter;
+    private final SmoothlyDecayingRollingCounter countCounter;
+    private final Id id;
+    private final double scale;
+    private final double[] percentiles;
+
+    public RollingDistributionSummary(Meter.Id id, DistributionStatisticConfig config, double scale, Clock clock) {
+        this.id = id;
+        this.scale = scale;
+        TickerClock tickerClock = new TickerClock(clock);
+        if (config.getBufferLength() == null) {
+            throw new IllegalArgumentException("distributionStatisticConfig.getBufferLength() should not be null");
+        }
+
+
+        if (config.getPercentiles() != null) {
+            percentiles = config.getPercentiles();
+        } else {
+            percentiles = new double[]{0.5, 0.95, 0.99};
+        }
+        Integer percentilePrecision = config.getPercentilePrecision();
+        if (percentilePrecision == null) {
+            percentilePrecision = 1;
+        }
+        Long maximumExpectedValue = config.getMaximumExpectedValue();
+        if (maximumExpectedValue == null) {
+            maximumExpectedValue = Long.MAX_VALUE;
+        }
+        rollingHdrHistogram = RollingHdrHistogram.builder()
+                .withSignificantDigits(percentilePrecision)
+                .resetReservoirPeriodicallyByChunks(config.getExpiry(), config.getBufferLength())
+                .withHighestTrackableValue(maximumExpectedValue, OverflowResolver.REDUCE_TO_HIGHEST_TRACKABLE)
+                .withPredefinedPercentiles(percentiles)
+                .withTicker(tickerClock)
+                .build();
+
+        totalAmountCounter = new SmoothlyDecayingRollingCounter(config.getExpiry(), config.getBufferLength(), tickerClock);
+        countCounter = new SmoothlyDecayingRollingCounter(config.getExpiry(), config.getBufferLength(), tickerClock);
+    }
+
+    @Override
+    public void record(double v) {
+        long value = (long) (v * scale);
+        totalAmountCounter.add(value);
+        countCounter.add(1);
+        rollingHdrHistogram.update(value);
+    }
+
+    @Override
+    public long count() {
+        return countCounter.getSum();
+    }
+
+    @Override
+    public double totalAmount() {
+        return totalAmountCounter.getSum();
+    }
+
+    @Override
+    public double max() {
+        return rollingHdrHistogram.getSnapshot().getMax();
+    }
+
+    @Override
+    public HistogramSnapshot takeSnapshot() {
+        RollingSnapshot snapshot = rollingHdrHistogram.getSnapshot();
+        ValueAtPercentile[] valuesAtPercentile = new ValueAtPercentile[percentiles.length];
+        for (int i = 0; i < percentiles.length; i++) {
+            double percentile = percentiles[i];
+            double value = snapshot.getValues()[i];
+            valuesAtPercentile[i] = new ValueAtPercentile(percentile, value);
+        }
+        return new HistogramSnapshot(
+                countCounter.getSum(),
+                totalAmountCounter.getSum(),
+                snapshot.getMax(),
+                valuesAtPercentile,
+                new CountAtBucket[0],
+                (printStream, aDouble) -> {
+                }
+        );
+    }
+
+    @Override
+    public Id getId() {
+        return id;
+    }
+}

--- a/rolling-metrics-micrometer/src/main/java/com/github/rollingmetrics/micrometer/meters/RollingDistributionSummary.java
+++ b/rolling-metrics-micrometer/src/main/java/com/github/rollingmetrics/micrometer/meters/RollingDistributionSummary.java
@@ -83,7 +83,7 @@ public class RollingDistributionSummary implements DistributionSummary {
         ValueAtPercentile[] valuesAtPercentile = new ValueAtPercentile[percentiles.length];
         for (int i = 0; i < percentiles.length; i++) {
             double percentile = percentiles[i];
-            double value = snapshot.getValues()[i];
+            double value = snapshot.getValue(percentile);
             valuesAtPercentile[i] = new ValueAtPercentile(percentile, value);
         }
         return new HistogramSnapshot(

--- a/rolling-metrics-micrometer/src/main/java/com/github/rollingmetrics/micrometer/meters/RollingFunctionCounter.java
+++ b/rolling-metrics-micrometer/src/main/java/com/github/rollingmetrics/micrometer/meters/RollingFunctionCounter.java
@@ -1,0 +1,50 @@
+package com.github.rollingmetrics.micrometer.meters;
+
+import com.github.rollingmetrics.counter.SmoothlyDecayingRollingCounter;
+import com.github.rollingmetrics.util.Ticker;
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.ToDoubleFunction;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class RollingFunctionCounter<T> implements FunctionCounter, Updatable {
+    private static final Logger logger = Logger.getLogger(RollingFunctionCounter.class.getName());
+    private final Id id;
+    private final T obj;
+    private final ToDoubleFunction<T> countFunction;
+    private final AtomicReference<Double> lastCount = new AtomicReference<>(0.0);
+    private final SmoothlyDecayingRollingCounter countCounter;
+
+    public RollingFunctionCounter(Id id, T obj, ToDoubleFunction<T> countFunction, DistributionStatisticConfig config, Ticker tickerClock) {
+        this.id = id;
+        this.obj = obj;
+        this.countFunction = countFunction;
+
+        countCounter = new SmoothlyDecayingRollingCounter(config.getExpiry(), config.getBufferLength(), tickerClock);
+    }
+
+    @Override
+    public double count() {
+        update();
+        return countCounter.getSum();
+    }
+
+    @Override
+    public Id getId() {
+        return id;
+    }
+
+    synchronized public void update() {
+        double currentCount = countFunction.applyAsDouble(obj);
+
+        if (currentCount < lastCount.get()) {
+            logger.log(Level.FINE, () -> "count function for function counter " + id + " returned value " + currentCount + " that is less that previous value " + lastCount);
+        } else {
+            countCounter.add((long) (currentCount - lastCount.get()));
+            lastCount.set(currentCount);
+        }
+    }
+}

--- a/rolling-metrics-micrometer/src/main/java/com/github/rollingmetrics/micrometer/meters/RollingFunctionTimer.java
+++ b/rolling-metrics-micrometer/src/main/java/com/github/rollingmetrics/micrometer/meters/RollingFunctionTimer.java
@@ -1,0 +1,80 @@
+package com.github.rollingmetrics.micrometer.meters;
+
+import com.github.rollingmetrics.counter.SmoothlyDecayingRollingCounter;
+import com.github.rollingmetrics.util.Ticker;
+import io.micrometer.core.instrument.FunctionTimer;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.util.TimeUtils;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToLongFunction;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class RollingFunctionTimer<T> implements FunctionTimer, Updatable {
+    private static final Logger logger = Logger.getLogger(RollingFunctionTimer.class.getName());
+    private final Id id;
+    private final T obj;
+    private final ToLongFunction<T> countFunction;
+    private final ToDoubleFunction<T> totalTimeFunction;
+    private final TimeUnit totalTimeFunctionUnit;
+    private final AtomicReference<Long> lastCount = new AtomicReference<>(0L);
+    private final AtomicReference<Double> lastTime = new AtomicReference<>(0.0);
+    private final SmoothlyDecayingRollingCounter countCounter;
+    private final SmoothlyDecayingRollingCounter timeCounter;
+
+    public RollingFunctionTimer(Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit, DistributionStatisticConfig config, Ticker tickerClock) {
+        this.id = id;
+        this.obj = obj;
+        this.countFunction = countFunction;
+        this.totalTimeFunction = totalTimeFunction;
+        this.totalTimeFunctionUnit = totalTimeFunctionUnit;
+
+        countCounter = new SmoothlyDecayingRollingCounter(config.getExpiry(), config.getBufferLength(), tickerClock);
+        timeCounter = new SmoothlyDecayingRollingCounter(config.getExpiry(), config.getBufferLength(), tickerClock);
+    }
+
+    @Override
+    public double count() {
+        update();
+        return countCounter.getSum();
+    }
+
+    @Override
+    public double totalTime(TimeUnit unit) {
+        update();
+        return timeCounter.getSum();
+    }
+
+    @Override
+    public TimeUnit baseTimeUnit() {
+        return TimeUnit.MILLISECONDS;
+    }
+
+    @Override
+    public Id getId() {
+        return id;
+    }
+
+    synchronized public void update() {
+        long currentCount = countFunction.applyAsLong(obj);
+
+        if (currentCount < lastCount.get()) {
+            logger.log(Level.FINE, () -> "count function for function timer " + id + " returned value " + currentCount + " that is less that previous value " + lastCount);
+        } else {
+            countCounter.add(currentCount - lastCount.get());
+            lastCount.set(currentCount);
+        }
+
+        double currentTime = TimeUtils.convert(totalTimeFunction.applyAsDouble(obj), totalTimeFunctionUnit, TimeUnit.MILLISECONDS);
+
+        if (currentTime < lastTime.get()) {
+            logger.log(Level.FINE, () -> "time function for function timer " + id + " returned value " + currentTime + " that is less that previous value " + lastTime);
+        } else {
+            timeCounter.add((long)(currentTime - lastTime.get()));
+            lastTime.set(currentTime);
+        }
+    }
+}

--- a/rolling-metrics-micrometer/src/main/java/com/github/rollingmetrics/micrometer/meters/RollingTimer.java
+++ b/rolling-metrics-micrometer/src/main/java/com/github/rollingmetrics/micrometer/meters/RollingTimer.java
@@ -1,0 +1,85 @@
+package com.github.rollingmetrics.micrometer.meters;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+import io.micrometer.core.instrument.util.TimeUtils;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+public class RollingTimer implements Timer {
+    private final RollingDistributionSummary distributionSummary;
+    private final Clock clock;
+
+    public RollingTimer(RollingDistributionSummary distributionSummary, Clock clock) {
+        this.distributionSummary = distributionSummary;
+        this.clock = clock;
+    }
+
+    @Override
+    public void record(long amount, TimeUnit unit) {
+        distributionSummary.record(TimeUtils.convert(amount, unit, TimeUnit.MILLISECONDS));
+    }
+
+    @Override
+    public <T> T record(Supplier<T> f) {
+        long startNanos = clock.monotonicTime();
+        try {
+            return f.get();
+        } finally {
+            record(clock.monotonicTime() - startNanos, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    @Override
+    public <T> T recordCallable(Callable<T> f) throws Exception {
+        long startNanos = clock.monotonicTime();
+        try {
+            return f.call();
+        } finally {
+            record(clock.monotonicTime() - startNanos, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    @Override
+    public void record(Runnable f) {
+        long startNanos = clock.monotonicTime();
+        try {
+            f.run();
+        } finally {
+            record(clock.monotonicTime() - startNanos, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    @Override
+    public long count() {
+        return distributionSummary.count();
+    }
+
+    @Override
+    public double totalTime(TimeUnit unit) {
+        return TimeUtils.convert(distributionSummary.totalAmount(), TimeUnit.MILLISECONDS, unit);
+    }
+
+    @Override
+    public double max(TimeUnit unit) {
+        return TimeUtils.convert(distributionSummary.max(), TimeUnit.MILLISECONDS, unit);
+    }
+
+    @Override
+    public TimeUnit baseTimeUnit() {
+        return TimeUnit.MILLISECONDS;
+    }
+
+    @Override
+    public HistogramSnapshot takeSnapshot() {
+        return distributionSummary.takeSnapshot();
+    }
+
+    @Override
+    public Id getId() {
+        return distributionSummary.getId();
+    }
+}

--- a/rolling-metrics-micrometer/src/main/java/com/github/rollingmetrics/micrometer/meters/TickerClock.java
+++ b/rolling-metrics-micrometer/src/main/java/com/github/rollingmetrics/micrometer/meters/TickerClock.java
@@ -1,0 +1,25 @@
+package com.github.rollingmetrics.micrometer.meters;
+
+import com.github.rollingmetrics.util.Ticker;
+import io.micrometer.core.instrument.Clock;
+
+public class TickerClock implements Ticker {
+
+    private final long initializationNanoTime;
+    private Clock clock;
+
+    public TickerClock(Clock clock) {
+        this.clock = clock;
+        initializationNanoTime = clock.monotonicTime();
+    }
+
+    @Override
+    public long nanoTime() {
+        return clock.monotonicTime();
+    }
+
+    @Override
+    public long stableMilliseconds() {
+        return  (nanoTime() - initializationNanoTime) / 1_000_000;
+    }
+}

--- a/rolling-metrics-micrometer/src/main/java/com/github/rollingmetrics/micrometer/meters/Updatable.java
+++ b/rolling-metrics-micrometer/src/main/java/com/github/rollingmetrics/micrometer/meters/Updatable.java
@@ -1,0 +1,5 @@
+package com.github.rollingmetrics.micrometer.meters;
+
+public interface Updatable {
+    void update();
+}

--- a/rolling-metrics-micrometer/src/test/java/com/github/rollingmetrics/micrometer/RollingMeterRegistryTest.java
+++ b/rolling-metrics-micrometer/src/test/java/com/github/rollingmetrics/micrometer/RollingMeterRegistryTest.java
@@ -90,6 +90,16 @@ public class RollingMeterRegistryTest {
     }
 
     @Test
+    public void newDistributionSummary_empty() {
+        DistributionSummary histogram = registry.summary("histogram");
+        HistogramSnapshot snapshot = histogram.takeSnapshot();
+        assertEquals(0, snapshot.count());
+        assertEquals(0, snapshot.max(), 0);
+        assertEquals(0, snapshot.mean(), 0);
+        assertEquals(0, snapshot.percentileValues()[0].value(), 0);
+    }
+
+    @Test
     public void newFunctionTimer() {
         AtomicLong counter = new AtomicLong(42);
         AtomicReference<Double> time = new AtomicReference<>(666.0);

--- a/rolling-metrics-micrometer/src/test/java/com/github/rollingmetrics/micrometer/RollingMeterRegistryTest.java
+++ b/rolling-metrics-micrometer/src/test/java/com/github/rollingmetrics/micrometer/RollingMeterRegistryTest.java
@@ -1,0 +1,115 @@
+package com.github.rollingmetrics.micrometer;
+
+import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+public class RollingMeterRegistryTest {
+
+    private final RollingMeterRegistry registry;
+    private final MockClock clock;
+
+    public RollingMeterRegistryTest() {
+        DistributionStatisticConfig config = DistributionStatisticConfig.builder()
+                .expiry(Duration.ofSeconds(10))
+                .bufferLength(3)
+                .build();
+        clock = new MockClock();
+        registry = new RollingMeterRegistry(config, clock);
+    }
+
+    @Test
+    public void newGauge() {
+        AtomicInteger value = new AtomicInteger(42);
+        registry.gauge("my-gauge", Collections.emptyList(), value, AtomicInteger::intValue);
+
+        Gauge gauge = getMeter("my-gauge");
+        assertEquals(42, gauge.value(), 0.0001);
+    }
+
+    @Test
+    public void newCounter() {
+        Counter counter = registry.counter("my-counter");
+        counter.increment();
+        counter.increment();
+        counter.increment();
+        assertEquals(3, counter.count(), 0.0001);
+    }
+
+    @Test
+    public void newLongTaskTimer() {
+        LongTaskTimer timer = LongTaskTimer.builder("my-long-timer").register(registry);
+        timer.start();
+        timer.start();
+        assertEquals(2, timer.activeTasks());
+    }
+
+    @Test
+    public void newTimer() {
+        Timer timer = registry.timer("my-timer");
+        timer.record(() -> {
+            clock.add(Duration.ofMillis(1000));
+        });
+        timer.record(() -> {
+            clock.add(Duration.ofMillis(100));
+        });
+        timer.record(() -> {
+            clock.add(Duration.ofMillis(500));
+        });
+
+        HistogramSnapshot snapshot = timer.takeSnapshot();
+        assertEquals(3, snapshot.count());
+        assertEquals(1000, snapshot.max(), 50);
+        assertEquals((1000 + 100 + 500) / 3.0, snapshot.mean(), 50);
+        assertEquals(500, snapshot.percentileValues()[0].value(), 50);
+    }
+
+    @Test
+    public void newDistributionSummary() {
+        DistributionSummary histogram = registry.summary("histogram");
+        histogram.record(1000);
+        histogram.record(500);
+        histogram.record(100);
+        HistogramSnapshot snapshot = histogram.takeSnapshot();
+        assertEquals(3, snapshot.count());
+        assertEquals(1000, snapshot.max(), 50);
+        assertEquals((1000 + 100 + 500) / 3.0, snapshot.mean(), 50);
+        assertEquals(500, snapshot.percentileValues()[0].value(), 50);
+    }
+
+    @Test
+    public void newFunctionTimer() {
+        AtomicLong counter = new AtomicLong(42);
+        AtomicReference<Double> time = new AtomicReference<>(666.0);
+
+        FunctionTimer timer = FunctionTimer.builder("timer", new Object(), value -> counter.get(), value -> time.get(), TimeUnit.MINUTES).register(registry);
+        assertEquals(42, timer.count(), 0.001);
+        assertEquals(60*666_000, timer.totalTime(TimeUnit.MILLISECONDS), 0.001);
+    }
+
+    @Test
+    public void newFunctionCounter() {
+        AtomicLong counter = new AtomicLong(42);
+        FunctionCounter counterr = FunctionCounter.builder("counter", new Object(), value -> counter.get()).register(registry);
+        assertEquals(42, counterr.count(), 0.001);
+    }
+
+    public <T extends Meter> T getMeter(String name) {
+        return (T) registry.getMeters().stream()
+                .filter(meter -> meter.getId().getName().equals(name))
+                .findAny()
+                .get();
+    }
+}


### PR DESCRIPTION
Note: Micrometer uses doubles everywhere, RollingMetrics prefer longs. Some conversions was done, but probably better solution will be to add DoubleWindowCounter to rolling-metrics-core.
